### PR TITLE
Switch orchestrator to .env runtime and expand observability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Premarket configuration sample
+# Copy to .env and customize values for your environment
+
+# Required: Finviz export URL (auth token will be redacted in logs)
+FINVIZ_EXPORT_URL="https://elite.finviz.com/export.ashx?...&auth=..."
+
+# Optional overrides
+PREMARKET_CONFIG_PATH="config/strategy.yaml"
+PREMARKET_OUT_DIR="data/watchlists"      # auto-appends YYYY-MM-DD
+PREMARKET_TOP_N=20
+PREMARKET_USE_CACHE=true
+PREMARKET_NEWS_ENABLED=false
+PREMARKET_MAX_PER_SECTOR=0.4
+PREMARKET_LOG_FILE=""                    # leave blank for default logs/premarket_<date>.log
+PREMARKET_DATE=""                         # YYYY-MM-DD for backfills
+PREMARKET_FAIL_ON_EMPTY=false
+PREMARKET_TZ="America/New_York"
+
+# Cache TTL for download fallback (optional)
+CACHE_TTL_MIN=60

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ A lightweight Python 3.11 project that pulls a Finviz Elite export, applies dete
 
 ## Quickstart
 
-1. Create and populate a `.env` file (or export variables in your shell):
+1. Copy the sample environment file and populate your values:
 
 ```bash
-export FINVIZ_EXPORT_URL="https://elite.finviz.com/export.ashx?...&auth=..."
-export CACHE_TTL_MIN=60  # optional
+cp .env.example .env
+# edit .env to add your Finviz export URL and optional overrides
 ```
 
 2. Install dependencies:
@@ -17,17 +17,15 @@ export CACHE_TTL_MIN=60  # optional
 pip install -e .[dev]
 ```
 
-3. Run the pipeline (example):
+3. Execute the workflow:
 
 ```bash
-python -m premarket.orchestrate \
-  --config config/strategy.yaml \
-  --out data/watchlists/$(date +%F) \
-  --top-n 20 \
-  --use-cache true
+python -m premarket
 ```
 
-On success, the following files will appear under the output directory:
+CLI flags are optional—any provided values override `.env` settings.
+
+On success, the following files appear under `PREMARKET_OUT_DIR/<YYYY-MM-DD>`:
 
 - `full_watchlist.json`: detailed data with features, scores, and tags.
 - `topN.json`: compact ranking summary for automation.
@@ -45,7 +43,26 @@ Strategy defaults live in `config/strategy.yaml`. Tune the thresholds and weight
 - Sector diversification ratio (`max_per_sector`).
 - Optional news settings (disabled by default).
 
-Override the Top-N size via CLI or edit `premarket.top_n` in the config.
+Override the Top-N size via `.env` (`PREMARKET_TOP_N`) or edit `premarket.top_n` in the config.
+
+### `.env` example
+
+```dotenv
+# Required Finviz export URL (auth token is automatically redacted in logs)
+FINVIZ_EXPORT_URL="https://elite.finviz.com/export.ashx?...&auth=..."
+
+# Runtime overrides (all optional)
+PREMARKET_CONFIG_PATH="config/strategy.yaml"
+PREMARKET_OUT_DIR="data/watchlists"      # YYYY-MM-DD is auto-appended
+PREMARKET_TOP_N=20                        # override YAML top_n
+PREMARKET_USE_CACHE=true                  # reuse downloads within CACHE_TTL_MIN
+PREMARKET_NEWS_ENABLED=false              # force news probe on/off
+PREMARKET_MAX_PER_SECTOR=0.4              # optional sector cap override
+PREMARKET_LOG_FILE="logs/premarket.log"  # defaults to logs/premarket_<date>.log
+PREMARKET_DATE=2025-10-01                 # backfill run date (timezone aware)
+PREMARKET_FAIL_ON_EMPTY=false             # return success even if no rows qualify
+PREMARKET_TZ="America/New_York"          # timezone for scheduling & logging
+```
 
 ## Testing
 
@@ -59,11 +76,16 @@ Coverage reports target ≥90% for core modules.
 
 ## Troubleshooting
 
-- **Auth errors**: verify `FINVIZ_EXPORT_URL` includes a valid `auth=` token and has not expired. Tokens are never logged; any errors will show a redacted URL.
-- **Header drift**: the normalizer maps multiple header synonyms. If Finviz introduces new names, update `premarket/normalize.py` with additional aliases.
-- **Missing columns**: the pipeline degrades gracefully—absent data defaults to neutral scores. Review `run_summary.json` for notes and adjust config thresholds if the dataset is sparse.
-- **Download failures**: the loader falls back to the most recent cached CSV when available. Increase `CACHE_TTL_MIN` if the service rate-limits frequent requests.
+| Exit code | Meaning | Common fixes |
+|-----------|---------|--------------|
+| `0` | Success (check `row_counts.topN` in `run_summary.json` to see how many symbols qualified). | No action required. If `topN` is zero, relax filters or keep `PREMARKET_FAIL_ON_EMPTY=false` to treat empty runs as expected. |
+| `2` | No symbols met the filters or were trimmed by sector caps. | Review `run_summary.json` (`row_counts`, `sector_cap_applied`) and adjust thresholds or caps. Ensure `PREMARKET_MAX_PER_SECTOR` is not overly restrictive. |
+| `3` | Failed to download or authenticate the Finviz export. | Verify `FINVIZ_EXPORT_URL` (token still valid), network connectivity, or run with `PREMARKET_USE_CACHE=true` to reuse cached data. |
 
 ## Logging & Observability
 
-Logs are written using Rich formatting. By default a log file is created under `logs/premarket_<date>.log`. The CLI also prints a concise completion summary showing qualified counts, tier distribution, cache usage, and output paths.
+- Logs are written with Rich formatting, and the Finviz URL is redacted to host + query keys (with `auth=` masked).
+- `run_summary.json` records `env_overrides_used`, `weights_version`, `csv_hash`, `row_counts`, `used_cached_csv`, `sector_cap_applied`, and `week52_warning_count` for easier auditing.
+- `watchlist.csv` includes a `Why` column plus `TopFeature1`–`TopFeature5` showing the primary drivers behind each pick.
+- The console summary prints a single line containing date, requested Top-N, tier counts, sector-cap status, cache usage, and output path.
+

--- a/premarket/__main__.py
+++ b/premarket/__main__.py
@@ -1,0 +1,213 @@
+"""Command-line entry point reading environment configuration."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from datetime import date, datetime
+from pathlib import Path
+from typing import Optional
+
+from dateutil import tz
+
+from . import orchestrate
+from . import utils
+
+_BOOL_TRUE = {"1", "true", "yes", "y", "on"}
+_BOOL_FALSE = {"0", "false", "no", "n", "off"}
+
+
+def _load_env_file(path: Path) -> None:
+    if not path.exists():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        os.environ.setdefault(key, value)
+
+
+def _parse_bool(value: Optional[str], key: str) -> Optional[bool]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    normalized = value.strip().lower()
+    if normalized in _BOOL_TRUE:
+        return True
+    if normalized in _BOOL_FALSE:
+        return False
+    raise ValueError(f"{key} must be a boolean-like value")
+
+
+def _today_in_timezone(tz_name: str) -> date:
+    tzinfo = tz.gettz(tz_name)
+    if tzinfo is None:
+        tzinfo = tz.gettz(utils.DEFAULT_TZ_NAME)
+    now = datetime.now(tz=tzinfo)
+    return now.date()
+
+
+def _parse_date(value: str, key: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:  # pragma: no cover - invalid user input
+        raise SystemExit(f"{key} must be in YYYY-MM-DD format") from exc
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Premarket Top-N watchlist runner")
+    parser.add_argument("--config", help="Override PREMARKET_CONFIG_PATH")
+    parser.add_argument("--out", help="Override PREMARKET_OUT_DIR")
+    parser.add_argument("--top-n", type=int, help="Override PREMARKET_TOP_N")
+    parser.add_argument("--use-cache", help="Override PREMARKET_USE_CACHE (true/false)")
+    parser.add_argument("--news", help="Override PREMARKET_NEWS_ENABLED (true/false)")
+    parser.add_argument("--log-file", help="Override PREMARKET_LOG_FILE")
+    parser.add_argument("--date", help="Override PREMARKET_DATE (YYYY-MM-DD)")
+    parser.add_argument("--tz", help="Override PREMARKET_TZ")
+    parser.add_argument("--max-per-sector", type=float, help="Override PREMARKET_MAX_PER_SECTOR")
+    parser.add_argument("--fail-on-empty", help="Override PREMARKET_FAIL_ON_EMPTY (true/false)")
+    parser.add_argument("--env-file", help="Path to .env file", default=".env")
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    env_path = Path(args.env_file)
+    _load_env_file(env_path)
+
+    overrides: set[str] = set()
+    env = os.environ
+
+    timezone = env.get("PREMARKET_TZ", utils.DEFAULT_TZ_NAME)
+    if "PREMARKET_TZ" in env:
+        overrides.add("PREMARKET_TZ")
+    if args.tz:
+        timezone = args.tz
+        overrides.add("PREMARKET_TZ")
+
+    run_date = _today_in_timezone(timezone)
+    if env.get("PREMARKET_DATE"):
+        run_date = _parse_date(env["PREMARKET_DATE"], "PREMARKET_DATE")
+        overrides.add("PREMARKET_DATE")
+    if args.date:
+        run_date = _parse_date(args.date, "PREMARKET_DATE")
+        overrides.add("PREMARKET_DATE")
+
+    config_value = env.get("PREMARKET_CONFIG_PATH", "config/strategy.yaml")
+    if "PREMARKET_CONFIG_PATH" in env:
+        overrides.add("PREMARKET_CONFIG_PATH")
+    if args.config:
+        config_value = args.config
+        overrides.add("PREMARKET_CONFIG_PATH")
+
+    out_value = env.get("PREMARKET_OUT_DIR")
+    output_base = Path(out_value) if out_value else Path("data/watchlists")
+    if out_value:
+        overrides.add("PREMARKET_OUT_DIR")
+    if args.out:
+        output_base = Path(args.out)
+        overrides.add("PREMARKET_OUT_DIR")
+
+    top_n: Optional[int] = None
+    if env.get("PREMARKET_TOP_N"):
+        try:
+            top_n = int(env["PREMARKET_TOP_N"])
+        except ValueError as exc:
+            raise SystemExit("PREMARKET_TOP_N must be an integer") from exc
+        overrides.add("PREMARKET_TOP_N")
+    if args.top_n is not None:
+        top_n = args.top_n
+        overrides.add("PREMARKET_TOP_N")
+
+    use_cache = True
+    try:
+        env_use_cache = _parse_bool(env.get("PREMARKET_USE_CACHE"), "PREMARKET_USE_CACHE")
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if env_use_cache is not None:
+        use_cache = env_use_cache
+        overrides.add("PREMARKET_USE_CACHE")
+    try:
+        cli_use_cache = _parse_bool(args.use_cache, "PREMARKET_USE_CACHE") if args.use_cache else None
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if cli_use_cache is not None:
+        use_cache = cli_use_cache
+        overrides.add("PREMARKET_USE_CACHE")
+
+    try:
+        news_override = _parse_bool(env.get("PREMARKET_NEWS_ENABLED"), "PREMARKET_NEWS_ENABLED")
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if news_override is not None:
+        overrides.add("PREMARKET_NEWS_ENABLED")
+    try:
+        cli_news = _parse_bool(args.news, "PREMARKET_NEWS_ENABLED") if args.news else None
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if cli_news is not None:
+        news_override = cli_news
+        overrides.add("PREMARKET_NEWS_ENABLED")
+
+    log_file: Optional[Path] = None
+    if env.get("PREMARKET_LOG_FILE"):
+        log_file = Path(env["PREMARKET_LOG_FILE"])
+        overrides.add("PREMARKET_LOG_FILE")
+    if args.log_file:
+        log_file = Path(args.log_file)
+        overrides.add("PREMARKET_LOG_FILE")
+
+    max_per_sector = None
+    if env.get("PREMARKET_MAX_PER_SECTOR"):
+        try:
+            max_per_sector = float(env["PREMARKET_MAX_PER_SECTOR"])
+        except ValueError as exc:
+            raise SystemExit("PREMARKET_MAX_PER_SECTOR must be numeric") from exc
+        overrides.add("PREMARKET_MAX_PER_SECTOR")
+    if args.max_per_sector is not None:
+        max_per_sector = args.max_per_sector
+        overrides.add("PREMARKET_MAX_PER_SECTOR")
+
+    fail_on_empty = False
+    try:
+        env_fail = _parse_bool(env.get("PREMARKET_FAIL_ON_EMPTY"), "PREMARKET_FAIL_ON_EMPTY")
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if env_fail is not None:
+        fail_on_empty = env_fail
+        overrides.add("PREMARKET_FAIL_ON_EMPTY")
+    try:
+        cli_fail = _parse_bool(args.fail_on_empty, "PREMARKET_FAIL_ON_EMPTY") if args.fail_on_empty else None
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if cli_fail is not None:
+        fail_on_empty = cli_fail
+        overrides.add("PREMARKET_FAIL_ON_EMPTY")
+
+    params = orchestrate.RunParams(
+        config_path=Path(config_value),
+        output_base_dir=output_base,
+        top_n=top_n,
+        use_cache=use_cache,
+        news_override=news_override,
+        log_file=log_file,
+        run_date=run_date,
+        timezone=timezone,
+        fail_on_empty=fail_on_empty,
+        max_per_sector=max_per_sector,
+        env_overrides=sorted(overrides),
+    )
+
+    return orchestrate.run(params)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/premarket/features.py
+++ b/premarket/features.py
@@ -67,8 +67,22 @@ def _after_hours_score(change: Any, day_change: Any) -> float:
 def _short_float_score(value: Any) -> float:
     pct = utils.safe_percent(value)
     if pct is None:
-        return 0.0
-    return float(np.clip((pct - 5) / (20 - 5), 0.0, 1.0))
+        return 0.5
+
+    lower = 5.0
+    upper = 20.0
+    sweet_mid = (lower + upper) / 2
+    half_width = (upper - lower) / 2
+
+    if pct < lower:
+        return float(np.clip(pct / lower * 0.5, 0.0, 0.5))
+    if pct > upper:
+        decay = max(0.0, 1 - (pct - upper) / 20)
+        return float(np.clip(decay * 0.6, 0.0, 1.0))
+
+    distance = abs(pct - sweet_mid)
+    normalized = 1 - (distance / half_width) ** 2
+    return float(np.clip(normalized, 0.0, 1.0))
 
 
 def _analyst_score(value: Any) -> float:

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -19,11 +19,11 @@ def test_normalize_columns_and_types():
     normalized = normalize.normalize_columns(df)
     assert "rel_volume" in normalized.columns
 
-    coerced = normalize.coerce_types(normalized)
+    coerced, warnings = normalize.coerce_types(normalized)
     assert coerced.loc[0, "rel_volume"] == 1.8
     assert coerced.loc[0, "avg_volume_3m"] == 1_500_000
     assert round(coerced.loc[0, "change_pct"], 2) == 5.0
     assert round(coerced.loc[0, "gap_pct"], 2) == round((18.5 - 17.5) / 17.5 * 100, 2)
 
-    week_pos = normalize.compute_week52_pos(coerced)
-    assert 0.0 <= week_pos.iloc[0] <= 1.0
+    assert 0.0 <= coerced.loc[0, "week52_pos"] <= 1.0
+    assert warnings == 0

--- a/tests/test_ranker.py
+++ b/tests/test_ranker.py
@@ -62,6 +62,7 @@ def test_sector_diversity():
             "score": [0.9, 0.8, 0.7],
         }
     )
-    capped = ranker.apply_sector_diversity(df, top_n=3, max_fraction=0.5)
+    capped, trimmed = ranker.apply_sector_diversity(df, top_n=3, max_fraction=0.5)
     assert len(capped) <= 3
+    assert trimmed is True
     assert (capped["sector"] == "Tech").sum() <= 1


### PR DESCRIPTION
## Summary
- add a `python -m premarket` entrypoint that loads `.env` defaults, supports optional CLI overrides, and passes a validated `RunParams`
- refactor orchestration to use env-driven settings, enrich `run_summary.json`, add sector-cap awareness, CSV hashing, and watchlist driver columns
- smooth short-float scoring, make 52-week range parsing neutral with warnings, redact Finviz auth in logs, and document the new flow with an `.env` example

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d6179433ac83318db667be9bc6519f