### PR TITLE
Configure setuptools to package only premarket

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,5 +25,8 @@ dev = [
   "pytest-cov"
 ]
 
+[tool.setuptools]
+packages = ["premarket"]
+
 [tool.pytest.ini_options]
 addopts = ""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,29 @@
+"""Tests for utility helpers."""
+
+from __future__ import annotations
+
+from premarket import utils
+
+
+def test_env_str_returns_default_when_missing(monkeypatch):
+    monkeypatch.delenv("SOME_KEY", raising=False)
+    assert utils.env_str("SOME_KEY", "fallback") == "fallback"
+
+
+def test_env_str_ignores_blank_and_comment_only_values(monkeypatch):
+    monkeypatch.setenv("EMPTY_VALUE", "   ")
+    assert utils.env_str("EMPTY_VALUE", "fallback") == "fallback"
+
+    monkeypatch.setenv("COMMENT_ONLY", "   # just a comment")
+    assert utils.env_str("COMMENT_ONLY", "fallback") == "fallback"
+
+
+def test_env_str_strips_inline_comment_when_separated(monkeypatch):
+    monkeypatch.setenv("WITH_COMMENT", "logs/premarket.log  # trailing note")
+    assert utils.env_str("WITH_COMMENT") == "logs/premarket.log"
+
+
+def test_env_str_preserves_hash_in_value(monkeypatch):
+    url = "https://example.com/path/#fragment"
+    monkeypatch.setenv("URL_VALUE", url)
+    assert utils.env_str("URL_VALUE") == url


### PR DESCRIPTION
## Summary
- configure setuptools in pyproject.toml to explicitly package only the premarket module

## Testing
- `pip install -e .[dev]` *(fails: ProxyError when attempting to download build dependency setuptools>=61.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d61f4f83748331bf0659a447930b5d