### PR TITLE
Sanitize CLI environment overrides

### DIFF
--- a/premarket/__main__.py
+++ b/premarket/__main__.py
@@ -84,42 +84,47 @@ def main(argv: Optional[list[str]] = None) -> int:
     _load_env_file(env_path)
 
     overrides: set[str] = set()
-    env = os.environ
 
-    timezone = env.get("PREMARKET_TZ", utils.DEFAULT_TZ_NAME)
-    if "PREMARKET_TZ" in env:
+    timezone = utils.DEFAULT_TZ_NAME
+    timezone_env = utils.env_str("PREMARKET_TZ")
+    if timezone_env is not None:
+        timezone = timezone_env
         overrides.add("PREMARKET_TZ")
     if args.tz:
         timezone = args.tz
         overrides.add("PREMARKET_TZ")
 
     run_date = _today_in_timezone(timezone)
-    if env.get("PREMARKET_DATE"):
-        run_date = _parse_date(env["PREMARKET_DATE"], "PREMARKET_DATE")
+    env_date = utils.env_str("PREMARKET_DATE")
+    if env_date is not None:
+        run_date = _parse_date(env_date, "PREMARKET_DATE")
         overrides.add("PREMARKET_DATE")
     if args.date:
         run_date = _parse_date(args.date, "PREMARKET_DATE")
         overrides.add("PREMARKET_DATE")
 
-    config_value = env.get("PREMARKET_CONFIG_PATH", "config/strategy.yaml")
-    if "PREMARKET_CONFIG_PATH" in env:
+    config_value = "config/strategy.yaml"
+    config_env = utils.env_str("PREMARKET_CONFIG_PATH")
+    if config_env is not None:
+        config_value = config_env
         overrides.add("PREMARKET_CONFIG_PATH")
     if args.config:
         config_value = args.config
         overrides.add("PREMARKET_CONFIG_PATH")
 
-    out_value = env.get("PREMARKET_OUT_DIR")
-    output_base = Path(out_value) if out_value else Path("data/watchlists")
-    if out_value:
+    out_value = utils.env_str("PREMARKET_OUT_DIR")
+    output_base = Path(out_value) if out_value is not None else Path("data/watchlists")
+    if out_value is not None:
         overrides.add("PREMARKET_OUT_DIR")
     if args.out:
         output_base = Path(args.out)
         overrides.add("PREMARKET_OUT_DIR")
 
     top_n: Optional[int] = None
-    if env.get("PREMARKET_TOP_N"):
+    top_env = utils.env_str("PREMARKET_TOP_N")
+    if top_env is not None:
         try:
-            top_n = int(env["PREMARKET_TOP_N"])
+            top_n = int(top_env)
         except ValueError as exc:
             raise SystemExit("PREMARKET_TOP_N must be an integer") from exc
         overrides.add("PREMARKET_TOP_N")
@@ -129,7 +134,7 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     use_cache = True
     try:
-        env_use_cache = _parse_bool(env.get("PREMARKET_USE_CACHE"), "PREMARKET_USE_CACHE")
+        env_use_cache = _parse_bool(utils.env_str("PREMARKET_USE_CACHE"), "PREMARKET_USE_CACHE")
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
     if env_use_cache is not None:
@@ -144,7 +149,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         overrides.add("PREMARKET_USE_CACHE")
 
     try:
-        news_override = _parse_bool(env.get("PREMARKET_NEWS_ENABLED"), "PREMARKET_NEWS_ENABLED")
+        news_override = _parse_bool(utils.env_str("PREMARKET_NEWS_ENABLED"), "PREMARKET_NEWS_ENABLED")
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
     if news_override is not None:
@@ -158,17 +163,19 @@ def main(argv: Optional[list[str]] = None) -> int:
         overrides.add("PREMARKET_NEWS_ENABLED")
 
     log_file: Optional[Path] = None
-    if env.get("PREMARKET_LOG_FILE"):
-        log_file = Path(env["PREMARKET_LOG_FILE"])
+    log_env = utils.env_str("PREMARKET_LOG_FILE")
+    if log_env is not None:
+        log_file = Path(log_env)
         overrides.add("PREMARKET_LOG_FILE")
     if args.log_file:
         log_file = Path(args.log_file)
         overrides.add("PREMARKET_LOG_FILE")
 
     max_per_sector = None
-    if env.get("PREMARKET_MAX_PER_SECTOR"):
+    max_per_sector_env = utils.env_str("PREMARKET_MAX_PER_SECTOR")
+    if max_per_sector_env is not None:
         try:
-            max_per_sector = float(env["PREMARKET_MAX_PER_SECTOR"])
+            max_per_sector = float(max_per_sector_env)
         except ValueError as exc:
             raise SystemExit("PREMARKET_MAX_PER_SECTOR must be numeric") from exc
         overrides.add("PREMARKET_MAX_PER_SECTOR")
@@ -178,7 +185,7 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     fail_on_empty = False
     try:
-        env_fail = _parse_bool(env.get("PREMARKET_FAIL_ON_EMPTY"), "PREMARKET_FAIL_ON_EMPTY")
+        env_fail = _parse_bool(utils.env_str("PREMARKET_FAIL_ON_EMPTY"), "PREMARKET_FAIL_ON_EMPTY")
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
     if env_fail is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,31 @@
+"""Tests for the CLI entry point."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from premarket import __main__ as cli
+
+
+def test_main_trims_commented_output_dir_env(monkeypatch, tmp_path):
+    captured: dict[str, Path] = {}
+
+    def fake_run(params):
+        captured["output_dir"] = params.output_base_dir
+        return 0
+
+    monkeypatch.setenv(
+        "PREMARKET_OUT_DIR",
+        'data/watchlists"      # auto-appends YYYY-MM-DD',
+    )
+    monkeypatch.setattr(cli.orchestrate, "run", fake_run)
+
+    # ensure the config path resolves without touching the real filesystem
+    config_path = tmp_path / "strategy.yaml"
+    config_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("PREMARKET_CONFIG_PATH", str(config_path))
+
+    exit_code = cli.main([])
+
+    assert exit_code == 0
+    assert captured["output_dir"] == Path("data/watchlists")


### PR DESCRIPTION
## Summary
- sanitize CLI overrides in `premarket.__main__` using the existing env_str helper so commented values no longer break path handling
- add a regression test covering PREMARKET_OUT_DIR strings with inline comments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6259bd5148331a95a27faa0c465b8