### PR TITLE
Handle Finviz numeric suffixes when normalizing data

### DIFF
--- a/premarket/utils.py
+++ b/premarket/utils.py
@@ -63,30 +63,83 @@ def setup_logging(log_file: Optional[Path] = None) -> logging.Logger:
     return logging.getLogger("premarket")
 
 
-def safe_float(value: Any) -> Optional[float]:
-    """Parse a value into float where possible."""
+_FINVIZ_SUFFIX_MULTIPLIERS = {
+    "K": 1_000,
+    "M": 1_000_000,
+    "B": 1_000_000_000,
+    "T": 1_000_000_000_000,
+}
+
+
+def _coerce_numeric(value: Any) -> Optional[float]:
+    """Coerce Finviz style numbers that may include suffixes into floats."""
+
     if value is None:
         return None
-    if isinstance(value, (int, float)):
-        if isinstance(value, bool):
-            return float(value)
+
+    if isinstance(value, bool):
         return float(value)
-    if isinstance(value, str):
-        stripped = value.strip()
-        if not stripped or stripped.upper() in {"N/A", "NA", "-"}:
-            return None
-        stripped = stripped.replace(",", "").replace("$", "")
-        try:
-            return float(stripped)
-        except ValueError:
-            return None
-    return None
+
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    if not isinstance(value, str):
+        return None
+
+    stripped = value.strip()
+    if not stripped:
+        return None
+
+    upper = stripped.upper()
+    if upper in {"N/A", "NA", "-"}:
+        return None
+
+    negative = False
+    if stripped.startswith("(") and stripped.endswith(")"):
+        stripped = stripped[1:-1]
+        negative = True
+
+    if stripped.startswith("+"):
+        stripped = stripped[1:]
+
+    if stripped.endswith("%"):
+        stripped = stripped[:-1].strip()
+
+    multiplier = 1.0
+    if stripped:
+        suffix = stripped[-1].upper()
+        if suffix in _FINVIZ_SUFFIX_MULTIPLIERS:
+            multiplier = _FINVIZ_SUFFIX_MULTIPLIERS[suffix]
+            stripped = stripped[:-1]
+
+    stripped = stripped.replace(",", "").replace("$", "")
+    if not stripped:
+        return None
+
+    try:
+        numeric = float(stripped)
+    except ValueError:
+        return None
+
+    if negative:
+        numeric = -numeric
+
+    numeric *= multiplier
+    return numeric
+
+
+def safe_float(value: Any) -> Optional[float]:
+    """Parse a value into float where possible."""
+
+    numeric = _coerce_numeric(value)
+    if numeric is None:
+        return None
+    return float(numeric)
 
 
 def safe_percent(value: Any) -> Optional[float]:
     """Parse percent values (with % sign) into floats."""
-    if isinstance(value, str):
-        value = value.replace("%", "")
+
     result = safe_float(value)
     if result is None:
         return None
@@ -94,18 +147,12 @@ def safe_percent(value: Any) -> Optional[float]:
 
 
 def safe_int(value: Any) -> Optional[int]:
-    """Parse integers with commas and symbols."""
-    if isinstance(value, (int, float)):
-        return int(value)
-    if isinstance(value, str):
-        stripped = value.strip().replace(",", "")
-        if not stripped or stripped.upper() in {"N/A", "NA", "-"}:
-            return None
-        try:
-            return int(float(stripped))
-        except ValueError:
-            return None
-    return None
+    """Parse integers with commas, symbols and Finviz suffixes."""
+
+    numeric = _coerce_numeric(value)
+    if numeric is None:
+        return None
+    return int(numeric)
 
 
 def parse_range(range_str: Any) -> Optional[tuple[float, float]]:

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -27,3 +27,22 @@ def test_normalize_columns_and_types():
 
     assert 0.0 <= coerced.loc[0, "week52_pos"] <= 1.0
     assert warnings == 0
+
+
+def test_coerce_types_parses_suffixes():
+    df = pd.DataFrame(
+        {
+            "Ticker": ["ZZZ"],
+            "Average Volume (3M)": ["850K"],
+            "Float": ["1.4B"],
+            "Short Float": ["12.5%"],
+        }
+    )
+
+    normalized = normalize.normalize_columns(df)
+    coerced, warnings = normalize.coerce_types(normalized)
+
+    assert coerced.loc[0, "avg_volume_3m"] == 850_000
+    assert coerced.loc[0, "float_shares"] == 1_400_000_000
+    assert coerced.loc[0, "short_float_pct"] == 12.5
+    assert warnings == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,17 @@ from __future__ import annotations
 from premarket import utils
 
 
+def test_safe_int_handles_finviz_suffixes():
+    assert utils.safe_int("850K") == 850_000
+    assert utils.safe_int("1.4M") == 1_400_000
+    assert utils.safe_int("2.5B") == 2_500_000_000
+
+
+def test_safe_int_handles_percent_strings():
+    assert utils.safe_int("65%") == 65
+    assert utils.safe_int(" 99.73% ") == 99
+
+
 def test_env_str_returns_default_when_missing(monkeypatch):
     monkeypatch.delenv("SOME_KEY", raising=False)
     assert utils.env_str("SOME_KEY", "fallback") == "fallback"


### PR DESCRIPTION
## Summary
- extend the numeric coercion helpers to understand Finviz suffixes like K/M/B/T and percent symbols so volume and float values survive type conversion
- add normalization and utility regression tests to cover the new parsing logic

## Testing
- pytest tests/test_utils.py tests/test_normalize.py -q
- pytest tests/test_orchestrate_e2e.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d811dca21c83319cecb4ec50b7c9fd